### PR TITLE
Relax the regular expression in Net::SSH::Shell::Process#on_stdout

### DIFF
--- a/lib/net/ssh/shell/process.rb
+++ b/lib/net/ssh/shell/process.rb
@@ -92,7 +92,7 @@ module Net; module SSH; class Shell
     end
 
     def on_stdout(ch, data)
-      if data.strip =~ /^#{manager.separator} (\d+)$/
+      if data.strip =~ /#{manager.separator} (\d+)$/
         before = $`
         output!(before) unless before.empty?
         finished!($1)


### PR DESCRIPTION
This regex made it so that `before` in the next line never can contain anything (because it matches the beginning of the `data` string). It therefor can never call finished! when there's any output on the last command?

With this change the code seems to work fine for me. I would have added a test if there were any.
